### PR TITLE
feat(converter): Add OCSF 1.5.0 schema compliance improvements

### DIFF
--- a/scripts/converters/base_converter.py
+++ b/scripts/converters/base_converter.py
@@ -46,6 +46,19 @@ class BaseOCSFConverter(ABC):
     ACTIVITY_NAME = "Update"
     OCSF_VERSION = "1.5.0"
 
+    # Default value for unknown/missing fields
+    UNKNOWN = "UNKNOWN"
+
+    # OCSF file type_id mapping
+    # See: https://schema.ocsf.io/1.5.0/objects/file
+    FILE_TYPE_REGULAR = 1  # Regular File
+    FILE_TYPE_FOLDER = 2  # Folder
+    FILE_TYPE_CHARACTER_DEVICE = 3  # Character Device
+    FILE_TYPE_BLOCK_DEVICE = 4  # Block Device
+    FILE_TYPE_PIPE = 5  # Local Socket
+    FILE_TYPE_SYMBOLIC_LINK = 6  # Symbolic Link
+    FILE_TYPE_UNKNOWN = 99  # Unknown
+
     def __init__(self, enrichments: list[EnrichmentPlugin] | None = None):
         """
         Initialize the converter.

--- a/scripts/converters/sarif_to_ocsf.py
+++ b/scripts/converters/sarif_to_ocsf.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from enrichments import FindingUIDGenerator, ScanMetadata, ScanMetadataEnrichment
 
@@ -111,10 +111,7 @@ class SARIFToOCSFConverter(BaseOCSFConverter):
 
             # Auto-extract scan_run_id from SARIF if available
             # Check if enrichments already contain scan_run_id
-            has_scan_run_id = any(
-                isinstance(e, ScanMetadataEnrichment)
-                for e in (self.enrichments or [])
-            )
+            has_scan_run_id = any(isinstance(e, ScanMetadataEnrichment) for e in (self.enrichments or []))
 
             # If no scan_run_id enrichment provided, try to extract from SARIF
             original_enrichments = self.enrichments
@@ -277,17 +274,17 @@ class SARIFToOCSFConverter(BaseOCSFConverter):
             Scan run ID string or None if not available
         """
         # Try automation details first (SARIF 2.1.0 spec)
-        automation = run.get('automationDetails', {})
-        if 'id' in automation:
-            return automation['id']
-        if 'guid' in automation:
-            return automation['guid']
+        automation = run.get("automationDetails", {})
+        if "id" in automation:
+            return automation["id"]
+        if "guid" in automation:
+            return automation["guid"]
 
         # Fallback: generate from tool + timestamp
-        tool_name = run.get('tool', {}).get('driver', {}).get('name', self.UNKNOWN)
-        invocations = run.get('invocations', [])
+        tool_name = run.get("tool", {}).get("driver", {}).get("name", self.UNKNOWN)
+        invocations = run.get("invocations", [])
         for invocation in invocations:
-            start_time = invocation.get('startTimeUtc')
+            start_time = invocation.get("startTimeUtc")
             if start_time:
                 return f"{tool_name}_run_{start_time}"
 
@@ -423,9 +420,9 @@ class SARIFToOCSFConverter(BaseOCSFConverter):
                 if file_path:
                     # OCSF 1.5.0 requires file.type_id and file.name; path is recommended
                     affected_code["file"] = {
-                        "name": file_path.split('/')[-1] if file_path else self.UNKNOWN,
+                        "name": file_path.split("/")[-1] if file_path else self.UNKNOWN,
                         "path": file_path,
-                        "type_id": self.FILE_TYPE_REGULAR
+                        "type_id": self.FILE_TYPE_REGULAR,
                     }
                 if start_line:
                     affected_code["start_line"] = start_line

--- a/scripts/enrichments/finding_uid_generator.py
+++ b/scripts/enrichments/finding_uid_generator.py
@@ -315,6 +315,7 @@ class FindingUIDGenerator(EnrichmentPlugin):
         # Add uid_generation enrichment
         uid_metadata = {
             "name": "uid_generation",
+            "value": f"UID generated using {method} method",
             "data": {"method": method, "version": version, "algorithm": "sha256"},
         }
 


### PR DESCRIPTION
## Summary

* Add required OCSF 1.5.0 schema fields for findings and vulnerabilities
* Improve handling of missing/unknown values with consistent UNKNOWN constant
* Restructure file and affected_code objects for proper schema compliance

## Motivation

The SARIF to OCSF converter was missing several required and recommended fields from the OCSF 1.5.0 schema specification, which could lead to validation issues and incomplete security finding data.

## Overview of changes

* **Status fields**: Added `status_id` (1) and `status` ("New") to all findings to properly track finding lifecycle
* **File object compliance**: Restructured `affected_code.file` as a proper OCSF file object with required `name` and `type_id` fields, plus recommended `path` field
* **Unknown value handling**: Introduced `UNKNOWN` constant for consistent handling of missing metadata across converters
* **Vulnerability structure**: Changed `affected_code` from dict to list to match OCSF schema array requirement
* **Smart CWE handling**: When location information is present but no CWE/CVE is found, set CWE to UNKNOWN to satisfy schema requirements while preserving location data
* **Enrichment metadata**: Added `value` field to uid_generation enrichment for better traceability
* **Test coverage**: Updated all tests to validate new schema structure and edge cases

---

*This PR description was generated with AI assistance.*