### PR TITLE
Handle null SARIF results in converter

### DIFF
--- a/scripts/CONTRIBUTING.md
+++ b/scripts/CONTRIBUTING.md
@@ -256,7 +256,8 @@ Best for consistent, isolated development:
 
 ```bash
 # Start the environment
-../scripts/run_podman.sh
+# Run from the repository root (the script lives in ./scripts/)
+./scripts/run_podman.sh
 
 # Access the container
 podman exec -it boann-app bash
@@ -507,4 +508,3 @@ See the [AGENTS.md](../AGENTS.md) file for comprehensive testing guidelines, inc
 - Open a new issue for bugs or feature requests
 
 Thank you for contributing!
-

--- a/scripts/converters/sarif_to_ocsf.py
+++ b/scripts/converters/sarif_to_ocsf.py
@@ -130,7 +130,14 @@ class SARIFToOCSFConverter(BaseOCSFConverter):
             rules_lookup = self._build_rules_lookup(run)
 
             # Process each result (finding)
-            for result in run.get("results", []):
+            # Some SARIF producers emit `"results": null` (or other non-list types); treat that as "no results"
+            # instead of crashing on `for result in None`.
+            results = run.get("results") or []
+            if not isinstance(results, list):
+                logger.warning("SARIF run 'results' is not a list; skipping this run")
+                results = []
+
+            for result in results:
                 try:
                     ocsf_finding = self._convert_result(result, tool_metadata, created_time, rules_lookup)
 

--- a/scripts/tests/test_sarif_converter.py
+++ b/scripts/tests/test_sarif_converter.py
@@ -236,6 +236,29 @@ class TestSARIFConverterMethods:
 
         assert "not found" in str(exc_info.value)
 
+    def test_convert_file_handles_null_results(self, converter):
+        """Test that a run with results=null does not crash and produces no findings."""
+        sarif_content = {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "TestTool", "version": "1.0.0"}},
+                    "results": None,
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sarif", delete=False) as f:
+            sarif_file = f.name
+            json.dump(sarif_content, f)
+
+        try:
+            findings = converter.convert_file(sarif_file)
+            assert findings == []
+        finally:
+            if Path(sarif_file).exists():
+                Path(sarif_file).unlink()
+
     def test_extract_created_time_with_invalid_timestamp(self, converter):
         """Test created time extraction with invalid timestamp format."""
         run = {"invocations": [{"startTimeUtc": "invalid-timestamp-format"}]}


### PR DESCRIPTION
Summary

- Handle SARIF runs where runs[].results is null (or otherwise not a list) without crashing.
- Add a regression test to ensure this edge case returns zero findings safely.

Why
Some SARIF producers can emit "results": null; previously this caused a TypeError when iterating results. This change makes the converter more robust to imperfect inputs.

Changes

- scripts/converters/sarif_to_ocsf.py: normalize run["results"] to an empty list when missing/null, warn+skip if it’s not a list.
- scripts/tests/test_sarif_converter.py: add test_convert_file_handles_null_results.

Test evidence
python -m pytest scripts/tests/test_sarif_converter.py -q
Result:

```
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/ptoraska/Documents/OrganizedAM14Pro/agents/boann-ocsf-security-data-platform
configfile: pyproject.toml
plugins: cov-6.0.0
collected 39 items

scripts/tests/test_sarif_converter.py .................................. [ 87%]
.....                                                                    [100%]

============================== 39 passed in 0.10s ==============================
```